### PR TITLE
Fix issue with Tungsten Crypto being an Objective-C project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.m linguist-vendored
+*.h linguist-vendored


### PR DESCRIPTION
What's up:

- Fix issue where Tungsten Crypto is detected by GitHub as Objective-C project (should be Swift project)